### PR TITLE
Don't fail to create a version if a field once present in the schema has been removed

### DIFF
--- a/plone/app/versioningbehavior/modifiers.py
+++ b/plone/app/versioningbehavior/modifiers.py
@@ -125,7 +125,8 @@ class CloneNamedFileBlobs:
             iface = resolveDottedName('.'.join(name.split('.')[:-1]))
             fname = name.split('.')[-1]
             field = iface.get(fname)
-            field.get(iface(obj))._blob = blob
+            if field is not None: # Field may have been removed from schema
+                field.get(iface(obj))._blob = blob
 
     def getOnCloneModifiers(self, obj):
         """Removes references to blobs.


### PR DESCRIPTION
When developing a versioned type, I removed a blob-backed field from my schema. This caused the CloneNamedFileBlobs class to fail as it tried to re-attach a blob from a field that no longer existed.

I'm not sure if there's a better way to fix this -- my patch feels a bit sticking-plaster?
