### PR TITLE
Deal with AttributeError when trying to access fields provided by behaviors using attribute storage.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Deal with AttributeError when trying to access fields provided by behaviors
+  using attribute storage.
+  [lgraf]
 
 
 1.1.3 (2014-02-26)

--- a/plone/app/versioningbehavior/modifiers.py
+++ b/plone/app/versioningbehavior/modifiers.py
@@ -113,7 +113,13 @@ class CloneNamedFileBlobs:
             for name, field in getFields(schemata).items():
                 if (INamedBlobFileField.providedBy(field) or
                     INamedBlobImageField.providedBy(field)):
-                    field_value = field.get(field.interface(obj))
+                    try:
+                        # field.get may raise an AttributeError if the field
+                        # is provided by a behavior and hasn't been
+                        # initialized yet
+                        field_value = field.get(field.interface(obj))
+                    except AttributeError:
+                        field_value = None
                     if field_value is None:
                         continue
                     blob_file = field_value.open()


### PR DESCRIPTION
When using [schema-only behaviors with attribute storage](http://docs.plone.org/external/plone.app.dexterity/docs/behaviors/schema-only-behaviors.html#storing-attributes), default values for fields get initialized rather late - particularly at the time object creation events get fired (e.g. `ObjectAddedEvent`), those fields may not have been initialized yet with default values. In that situation, the attribute isn't present on the object yet, and trying to access it using `field.get()` will raise an `AttributeError`.

Since `field.get()` doesn't allow for providing a default value, this change wraps the field access in `getReferencedAttributes` with a `try...except AttributeError`.
