### PR TITLE
Remove reference to itself

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ tests_require = [
     'Products.CMFPlone',
     'plone.app.dexterity',
     'plone.app.testing',
-    'plone.app.versioningbehavior',
     'plone.namedfile[blobs]',
     'zope.app.intid',
     ]


### PR DESCRIPTION
There should be no need to list the distribution itself as a testing requirement, right?