### PR TITLE
Fix ats migrated to dxs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Do not break in the case of dexterity objects with relations
+  migrated from something else (usually Archetypes).
+  [ale-rt]
 
 
 1.2.9 (2016-08-18)

--- a/plone/app/versioningbehavior/modifiers.py
+++ b/plone/app/versioningbehavior/modifiers.py
@@ -214,7 +214,10 @@ class SkipRelations:
 
     def afterRetrieveModifier(self, obj, repo_clone, preserve=()):
         """Restore relations from the working copy."""
-        if IDexterityContent.providedBy(obj):
+        if (
+            IDexterityContent.providedBy(obj) and
+            IDexterityContent.providedBy(repo_clone)
+        ):
             for schemata in iterSchemata(obj):
                 for name, field in getFields(schemata).items():
                     if (IRelationChoice.providedBy(field) or

--- a/plone/app/versioningbehavior/tests/test_modifiers.py
+++ b/plone/app/versioningbehavior/tests/test_modifiers.py
@@ -54,7 +54,8 @@ class TestModifiers(CMFEditionsBaseTestCase):
             model_source="""
             <model xmlns="http://namespaces.plone.org/supermodel/schema">
                 <schema>
-                    <field name="file" type="plone.namedfile.field.NamedBlobFile">
+                    <field name="file"
+                           type="plone.namedfile.field.NamedBlobFile">
                         <title>File</title>
                         <required>True</required>
                     </field>
@@ -126,7 +127,8 @@ class TestModifiers(CMFEditionsBaseTestCase):
             model_source="""
             <model xmlns="http://namespaces.plone.org/supermodel/schema">
                 <schema>
-                    <field name="file" type="plone.namedfile.field.NamedBlobFile">
+                    <field name="file"
+                           type="plone.namedfile.field.NamedBlobFile">
                         <title>File</title>
                         <required>True</required>
                     </field>
@@ -138,7 +140,8 @@ class TestModifiers(CMFEditionsBaseTestCase):
         file1 = createContentInContainer(self.portal, 'BlobFile')
         file1.file = NamedBlobFile('dummy test data', filename=u'test.txt')
         modifier = CloneNamedFileBlobs('modifier', 'Modifier')
-        pers_id, pers_load, empty1, empty2 = modifier.getOnCloneModifiers(file1)
+        on_clone_modifiers = modifier.getOnCloneModifiers(file1)
+        pers_id, pers_load, empty1, empty2 = on_clone_modifiers
         self.assertTrue(pers_id(file1.file._blob))
         self.assertTrue(pers_load(file1.file._blob) is None)
         self.assertTrue(empty1 == [])
@@ -150,7 +153,8 @@ class TestModifiers(CMFEditionsBaseTestCase):
             model_source="""
             <model xmlns="http://namespaces.plone.org/supermodel/schema">
                 <schema>
-                    <field name="file" type="plone.namedfile.field.NamedBlobFile">
+                    <field name="file"
+                           type="plone.namedfile.field.NamedBlobFile">
                         <title>File</title>
                         <required>True</required>
                     </field>
@@ -162,7 +166,8 @@ class TestModifiers(CMFEditionsBaseTestCase):
         modifier = CloneNamedFileBlobs('modifier', 'Modifier')
         attrs_dict = modifier.getReferencedAttributes(file1)
         self.assertTrue(attrs_dict == {})
-        pers_id, pers_load, empty1, empty2 = modifier.getOnCloneModifiers(file1)
+        on_clone_modifiers = modifier.getOnCloneModifiers(file1)
+        pers_id, pers_load, empty1, empty2 = on_clone_modifiers
         self.assertTrue(pers_id(None) is None)
         self.assertTrue(pers_load(None) is None)
         self.assertTrue(empty1 == [])
@@ -177,7 +182,8 @@ class TestModifiers(CMFEditionsBaseTestCase):
             in attrs_dict)
         blob = attrs_dict.values()[0]
         self.assertTrue(IBlob.providedBy(blob))
-        pers_id, pers_load, empty1, empty2 = modifier.getOnCloneModifiers(file1)
+        on_clone_modifiers = modifier.getOnCloneModifiers(file1)
+        pers_id, pers_load, empty1, empty2 = on_clone_modifiers
         self.assertTrue(pers_id(file1.file._blob))
         self.assertTrue(pers_load(file1.file._blob) is None)
         self.assertTrue(empty1 == [])
@@ -186,7 +192,8 @@ class TestModifiers(CMFEditionsBaseTestCase):
     def testRelations(self):
         rel_fti = DexterityFTI(
             'RelationsType',
-            schema='plone.app.versioningbehavior.tests.test_modifiers.IRelationsType')
+            schema=IRelationsType.__identifier__
+        )
         self.portal.portal_types._setObject('RelationsType', rel_fti)
 
         # Setup IIntIds utility which is required for relations to work
@@ -200,7 +207,8 @@ class TestModifiers(CMFEditionsBaseTestCase):
 
         # Test modifier when no relations are set
         modifier = SkipRelations('modifier', 'Modifier')
-        pers_id, pers_load, empty1, empty2 = modifier.getOnCloneModifiers(source)
+        on_clone_modifiers = modifier.getOnCloneModifiers(source)
+        pers_id, pers_load, empty1, empty2 = on_clone_modifiers
         self.assertTrue(pers_id(None) is None)
         self.assertTrue(pers_id(None) is None)
         self.assertTrue(pers_load(None) is None)
@@ -223,7 +231,8 @@ class TestModifiers(CMFEditionsBaseTestCase):
         notify(ObjectModifiedEvent(source))
 
         modifier = SkipRelations('modifier', 'Modifier')
-        pers_id, pers_load, empty1, empty2 = modifier.getOnCloneModifiers(source)
+        on_clone_modifiers = modifier.getOnCloneModifiers(source)
+        pers_id, pers_load, empty1, empty2 = on_clone_modifiers
         self.assertTrue(pers_id(source.single))
         self.assertTrue(pers_id(source.multiple))
         self.assertTrue(pers_load(source.single) is None)
@@ -270,7 +279,8 @@ class TestModifiers(CMFEditionsBaseTestCase):
 
         # Test modifier when no relations are set
         modifier = SkipRelations('modifier', 'Modifier')
-        pers_id, pers_load, empty1, empty2 = modifier.getOnCloneModifiers(source)
+        on_clone_modifiers = modifier.getOnCloneModifiers(source)
+        pers_id, pers_load, empty1, empty2 = on_clone_modifiers
         self.assertTrue(pers_id(None) is None)
         self.assertTrue(pers_id(None) is None)
         self.assertTrue(pers_load(None) is None)
@@ -284,8 +294,12 @@ class TestModifiers(CMFEditionsBaseTestCase):
         self.assertTrue(repo_clone.multiple is None)
 
         # Add some relations
-        IRelationsBehavior(source).single = RelationValue(intids.getId(target))
-        IRelationsBehavior(source).multiple = [RelationValue(intids.getId(target))]
+        IRelationsBehavior(source).single = RelationValue(
+            intids.getId(target)
+        )
+        IRelationsBehavior(source).multiple = [
+            RelationValue(intids.getId(target))
+        ]
 
         # Update relations
         from zope.lifecycleevent import ObjectModifiedEvent
@@ -293,7 +307,8 @@ class TestModifiers(CMFEditionsBaseTestCase):
         notify(ObjectModifiedEvent(source))
 
         modifier = SkipRelations('modifier', 'Modifier')
-        pers_id, pers_load, empty1, empty2 = modifier.getOnCloneModifiers(source)
+        on_clone_modifiers = modifier.getOnCloneModifiers(source)
+        pers_id, pers_load, empty1, empty2 = on_clone_modifiers
         self.assertTrue(pers_id(IRelationsBehavior(source).single))
         self.assertTrue(pers_id(IRelationsBehavior(source).multiple))
         self.assertTrue(pers_load(IRelationsBehavior(source).single) is None)


### PR DESCRIPTION
Do not break everytime on ObjectModifiedEvent if a non dexterity object has been transformed in to a dexterity object after a migration.