### PR TITLE
Modernize/ Code overhaul

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,20 +1,22 @@
 Changelog
 =========
 
-1.2.11 (unreleased)
--------------------
+2.0.0 (unreleased)
+------------------
 
 Breaking changes:
 
-- *add item here*
+- Drop support for Dexterity 1.x
+  [jensens]
 
 New features:
 
-- *add item here*
+- Register behavior with shortname `plone.versioning`.
 
 Bug fixes:
 
-- *add item here*
+- Cleanup: pep8, isort, uth8headers, ...
+  [jensens]
 
 
 1.2.10 (2016-09-23)

--- a/plone/__init__.py
+++ b/plone/__init__.py
@@ -1,6 +1,2 @@
-# See http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    from pkgutil import extend_path
-    __path__ = extend_path(__path__, __name__)
+# -*- coding: utf-8 -*-
+__import__('pkg_resources').declare_namespace(__name__)

--- a/plone/app/__init__.py
+++ b/plone/app/__init__.py
@@ -1,6 +1,2 @@
-# See http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    from pkgutil import extend_path
-    __path__ = extend_path(__path__, __name__)
+# -*- coding: utf-8 -*-
+__import__('pkg_resources').declare_namespace(__name__)

--- a/plone/app/versioningbehavior/__init__.py
+++ b/plone/app/versioningbehavior/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from plone.namedfile.interfaces import HAVE_BLOBS
+from plone.app.versionbehavior.modifiers import modifiers
 from Products.CMFCore.permissions import ManagePortal
-
 from zope.i18nmessageid import MessageFactory
+
 
 _ = MessageFactory('plone')
 
@@ -10,13 +10,12 @@ _ = MessageFactory('plone')
 def initialize(context):
     """Registers modifiers with zope (on zope startup).
     """
-    if HAVE_BLOBS:
-        from modifiers import modifiers
 
-        for m in modifiers:
-            context.registerClass(
-                m['wrapper'], m['id'],
-                permission=ManagePortal,
-                constructors=(m['form'], m['factory']),
-                icon=m['icon'],
-            )
+    for mod in modifiers:
+        context.registerClass(
+            mod['wrapper'],
+            mod['id'],
+            permission=ManagePortal,
+            constructors=(mod['form'], mod['factory']),
+            icon=mod['icon'],
+        )

--- a/plone/app/versioningbehavior/behaviors.py
+++ b/plone/app/versioningbehavior/behaviors.py
@@ -8,12 +8,13 @@ from z3c.form.interfaces import IAddForm
 from z3c.form.interfaces import IEditForm
 from zope import schema
 from zope.annotation.interfaces import IAnnotations
-from zope.component import adapts
-from zope.interface import alsoProvides
+from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
+from zope.interface import provider
 
 
+@provider(IFormFieldProvider)
 class IVersionable(model.Schema):
     """ Behavior for enabling CMFEditions's versioning for dexterity
     content types. Be shure to enable versioning in the plone types
@@ -22,17 +23,17 @@ class IVersionable(model.Schema):
 
     changeNote = schema.TextLine(
         title=_(u'label_change_note', default=u'Change Note'),
-        description=_(u'help_change_note',
-                      default=u'Enter a comment that describes the changes you made. '
-                              u'If versioning is manual, you must set a change note '
-                              u'to create the new version.'),
+        description=_(
+            u'help_change_note',
+            default=u'Enter a comment that describes the changes you made. '
+                    u'If versioning is manual, you must set a change note '
+                    u'to create the new version.'
+        ),
         required=False)
 
     form.omitted('changeNote')
     form.no_omit(IEditForm, 'changeNote')
     form.no_omit(IAddForm, 'changeNote')
-
-alsoProvides(IVersionable, IFormFieldProvider)
 
 
 class IVersioningSupport(Interface):
@@ -42,12 +43,12 @@ class IVersioningSupport(Interface):
 
 
 @implementer(IVersionable)
+@adapter(IDexterityContent)
 class Versionable(object):
     """ The Versionable adapter prohibits dexterity from saving the changeNote
     on the context. It stores it in a request-annotation for later use in
     event-handlers
     """
-    adapts(IDexterityContent)
 
     def __init__(self, context):
         self.context = context

--- a/plone/app/versioningbehavior/configure.zcml
+++ b/plone/app/versioningbehavior/configure.zcml
@@ -11,23 +11,15 @@
     i18n_domain="plone">
 
     <include package="plone.behavior" file="meta.zcml" />
-
     <include package="plone.rfc822" />
+    <include package="plone.app.dexterity" />
 
     <five:registerPackage package="." initialize=".initialize" />
 
-    <include package="plone.app.dexterity" />
 
-    <!-- Dexterity 1.x uses grok / martian based directive.
-         Newer dexterity versions do not use grok anymore.
-         For supporting the old versions we grok the package if
-         grok is installed. /-->
-    <configure zcml:condition="installed five.grok">
-        <include package="five.grok" />
-        <grok:grok package="." />
-    </configure>
 
     <plone:behavior
+        name="plone.versionable"
         title="Versioning"
         description="Versioning support with CMFEditions"
         provides=".behaviors.IVersionable"

--- a/plone/app/versioningbehavior/modifiers.py
+++ b/plone/app/versioningbehavior/modifiers.py
@@ -2,8 +2,9 @@
 from Acquisition import aq_base
 from App.class_init import InitializeClass
 from itertools import izip
-from plone.dexterity.utils import iterSchemata, resolveDottedName
 from plone.dexterity.interfaces import IDexterityContent
+from plone.dexterity.utils import iterSchemata
+from plone.dexterity.utils import resolveDottedName
 from plone.namedfile.interfaces import INamedBlobFileField
 from plone.namedfile.interfaces import INamedBlobImageField
 from Products.CMFCore.utils import getToolByName
@@ -13,10 +14,11 @@ from Products.CMFEditions.interfaces.IModifier import ICloneModifier
 from Products.CMFEditions.interfaces.IModifier import ISaveRetrieveModifier
 from Products.CMFEditions.Modifiers import ConditionalTalesModifier
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
+from z3c.relationfield.interfaces import IRelationChoice
+from z3c.relationfield.interfaces import IRelationList
 from ZODB.blob import Blob
 from zope.interface import implementer
 from zope.schema import getFields
-from z3c.relationfield.interfaces import IRelationChoice, IRelationList
 
 import os
 
@@ -225,6 +227,7 @@ class SkipRelations:
                         field.set(field.interface(repo_clone),
                                   field.query(field.interface(obj)))
         return [], [], {}
+
 
 InitializeClass(SkipRelations)
 

--- a/plone/app/versioningbehavior/setuphandlers.py
+++ b/plone/app/versioningbehavior/setuphandlers.py
@@ -6,19 +6,19 @@ from Products.CMFEditions.interfaces.IModifier import IConditionalTalesModifier
 
 def install_modifiers(context, logger):
     portal_modifier = getToolByName(context, 'portal_modifier')
-    for m in modifiers:
-        id_ = m['id']
-        if id_ in portal_modifier.objectIds():
+    for entry in modifiers:
+        eid = entry['id']
+        if eid in portal_modifier.objectIds():
             continue
-        title = m['title']
-        modifier = m['modifier'](id_, title)
-        wrapper = m['wrapper'](id_, modifier, title)
-        enabled = m['enabled']
+        title = entry['title']
+        modifier = entry['modifier'](eid, title)
+        wrapper = eid['wrapper'](eid, modifier, title)
+        enabled = eid['enabled']
         if IConditionalTalesModifier.providedBy(wrapper):
-            wrapper.edit(enabled, m['condition'])
+            wrapper.edit(enabled, entry['condition'])
         else:
             wrapper.edit(enabled)
-        portal_modifier.register(m['id'], wrapper)
+        portal_modifier.register(entry['id'], wrapper)
 
 
 def disable_skip_z3c_blobfile(context, logger):

--- a/plone/app/versioningbehavior/subscribers.py
+++ b/plone/app/versioningbehavior/subscribers.py
@@ -2,8 +2,8 @@
 from plone.app.versioningbehavior import _
 from plone.app.versioningbehavior.utils import get_change_note
 from Products.CMFCore.utils import getToolByName
-from Products.CMFEditions.interfaces.IArchivist import ArchivistUnregisteredError
-from Products.CMFEditions.interfaces.IModifier import FileTooLargeToVersionError
+from Products.CMFEditions.interfaces.IArchivist import ArchivistUnregisteredError  # noqa
+from Products.CMFEditions.interfaces.IModifier import FileTooLargeToVersionError  # noqa
 from Products.CMFPlone.utils import base_hasattr
 from zope.container.interfaces import IContainerModifiedEvent
 

--- a/plone/app/versioningbehavior/testing.py
+++ b/plone/app/versioningbehavior/testing.py
@@ -1,26 +1,35 @@
 # -*- coding: utf-8 -*-
-from Products.CMFCore.utils import getToolByName
-from Products.CMFDiffTool.TextDiff import TextDiff
+from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import applyProfile
 from plone.dexterity.fti import DexterityFTI
+from plone.protect import auto as protect_auto
+from Products.CMFCore.utils import getToolByName
+from Products.CMFDiffTool.TextDiff import TextDiff
 from zope.configuration import xmlconfig
-
-# Make it work with plone.protect < 3.0.0 where the `auto` module is not available.
-# This is necessary for Plone 4.3.x compatibility.
-try:
-    from plone.protect import auto as protect_auto
-except ImportError:
-    class DummyAuto(object):
-        CSRF_DISABLED = True
-    protect_auto = DummyAuto()
 
 
 TEST_CONTENT_TYPE_ID = 'TestContentType'
 DEFAULT_POLICIES = ('at_edit_autoversion', 'version_on_revert',)
+
+MODEL_SOURCE = """
+<model xmlns="http://namespaces.plone.org/supermodel/schema"
+       xmlns:marshal="http://namespaces.plone.org/supermodel/marshal">
+    <schema>
+        <field name="text" type="zope.schema.Text">
+            <title>Text</title>
+            <required>False</required>
+        </field>
+        <field name="file" type="plone.namedfile.field.NamedBlobFile"
+            marshal:primary="true">
+          <title>File</title>
+          <required>False</required>
+        </field>
+    </schema>
+</model>
+"""
 
 
 class VersioningLayer(PloneSandboxLayer):
@@ -41,25 +50,10 @@ class VersioningLayer(PloneSandboxLayer):
             TEST_CONTENT_TYPE_ID,
             global_allow=True,
             behaviors=(
-                'plone.app.versioningbehavior.behaviors.IVersionable',
-                'plone.app.dexterity.behaviors.metadata.IBasic',
+                'plone.versionable',
+                'plone.basic',
             ),
-            model_source="""
-                <model xmlns="http://namespaces.plone.org/supermodel/schema"
-                       xmlns:marshal="http://namespaces.plone.org/supermodel/marshal">
-                    <schema>
-                        <field name="text" type="zope.schema.Text">
-                            <title>Text</title>
-                            <required>False</required>
-                        </field>
-                        <field name="file" type="plone.namedfile.field.NamedBlobFile"
-                            marshal:primary="true">
-                          <title>File</title>
-                          <required>False</required>
-                        </field>
-                    </schema>
-                </model>
-                """)
+            model_source=MODEL_SOURCE)
         types_tool._setObject(TEST_CONTENT_TYPE_ID, fti)
 
         diff_tool = getToolByName(portal, 'portal_diff')
@@ -85,7 +79,9 @@ class VersioningLayer(PloneSandboxLayer):
 VERSIONING_FIXTURE = VersioningLayer()
 VERSIONING_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(VERSIONING_FIXTURE,),
-    name='plone.app.versioningbehavior:functional')
+    name='plone.app.versioningbehavior:functional'
+)
 VERSIONING_INTEGRATION_TESTING = IntegrationTesting(
     bases=(VERSIONING_FIXTURE,),
-    name='plone.app.versioningbehavior:integration')
+    name='plone.app.versioningbehavior:integration'
+)

--- a/plone/app/versioningbehavior/tests/doctest_behavior.rst
+++ b/plone/app/versioningbehavior/tests/doctest_behavior.rst
@@ -1,3 +1,4 @@
+::
 
     >>> from plone.app.testing import TEST_USER_ID
     >>> from plone.app.testing import TEST_USER_NAME

--- a/plone/app/versioningbehavior/tests/test_IntegrationTests.py
+++ b/plone/app/versioningbehavior/tests/test_IntegrationTests.py
@@ -93,7 +93,10 @@ class TestDexterityIntegration(test_IntegrationTests.TestIntegration):
 
         # We have a test that fails without workflow.
         wf_tool = getToolByName(self.portal, 'portal_workflow')
-        wf_tool.setChainForPortalTypes(('Document',), ('simple_publication_workflow',))
+        wf_tool.setChainForPortalTypes(
+            ('Document',),
+            ('simple_publication_workflow',)
+        )
 
     def test13_revertUpdatesCatalog(self):
         # This test in CMFEditions uses doc.edit, but we have no archetypes

--- a/plone/app/versioningbehavior/tests/test_browser.py
+++ b/plone/app/versioningbehavior/tests/test_browser.py
@@ -2,12 +2,16 @@
 """Tests for the `browser` module."""
 from .. import browser
 from ..testing import VERSIONING_INTEGRATION_TESTING
-from plone.app.testing import TEST_USER_ID, TEST_USER_ROLES, setRoles
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_ROLES
 from plone.app.versioningbehavior.testing import TEST_CONTENT_TYPE_ID
 from plone.namedfile import NamedBlobFile
 from zope.component import getMultiAdapter
+
 import re
 import unittest
+
 
 class BaseViewTestCase(unittest.TestCase):
 
@@ -23,7 +27,10 @@ class BaseViewTestCase(unittest.TestCase):
             title=u'Object 1 Title',
             description=u'Description of obect number 1',
             text=u'Object 1 some footext.',
-            file=NamedBlobFile(filename=u'object_1_file.txt', data='Object 1 Data'),
+            file=NamedBlobFile(
+                filename=u'object_1_file.txt',
+                data='Object 1 Data'
+            ),
         )
         self.obj1 = self.portal['obj1']
 

--- a/plone/app/versioningbehavior/tests/test_functional.py
+++ b/plone/app/versioningbehavior/tests/test_functional.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
+from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
-from plone.app.testing import setRoles
 from plone.app.versioningbehavior.testing import TEST_CONTENT_TYPE_ID
 from plone.app.versioningbehavior.testing import VERSIONING_FUNCTIONAL_TESTING
 from plone.testing.z2 import Browser
+
 import transaction
 import unittest
 
@@ -21,7 +22,9 @@ class FunctionalTestCase(unittest.TestCase):
         self.browser = Browser(self.layer['app'])
         self.browser.handleErrors = False
         self.browser.addHeader(
-            'Authorization', 'Basic %s:%s' % (TEST_USER_NAME, TEST_USER_PASSWORD,))
+            'Authorization',
+            'Basic %s:%s' % (TEST_USER_NAME, TEST_USER_PASSWORD,)
+        )
 
         setRoles(self.portal, TEST_USER_ID, ['Manager', 'Member'])
         self.portal.invokeFactory(
@@ -76,12 +79,18 @@ class FunctionalTestCase(unittest.TestCase):
 
         if version_id == 0:
             self.assertIn(
-                '/%s/versions_history_form?version_id=%s' % (obj_id, version_id),
-                self.browser.contents)
+                '/{0}/versions_history_form?version_id={1}'.format(
+                    obj_id,
+                    version_id
+                ),
+                self.browser.contents
+            )
         self.assertIn('Working Copy', self.browser.contents)
         self.assertIn('Revert to this revision', self.browser.contents)
         self.assertIn(
-            '/%s/@@history?one' % obj_id, self.browser.contents)
+            '/%s/@@history?one' % obj_id,
+            self.browser.contents
+        )
         self.assertIn('Preview of Revision %s' % version_id,
                       self.browser.contents)
         self.assertIn('<h1 class="documentFirstHeading">%s</h1>' % str(title),

--- a/plone/app/versioningbehavior/tests/test_modifiers.py
+++ b/plone/app/versioningbehavior/tests/test_modifiers.py
@@ -1,29 +1,33 @@
 # -*- coding: utf-8 -*-
+from ..testing import VERSIONING_INTEGRATION_TESTING
 from five.intid import site
 from plone.app.versioningbehavior.modifiers import CloneNamedFileBlobs
 from plone.app.versioningbehavior.modifiers import SkipRelations
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.fti import DexterityFTI
-from plone.dexterity.utils import createContentInContainer, createContent
+from plone.dexterity.utils import createContent
+from plone.dexterity.utils import createContentInContainer
 from plone.namedfile import field
 from plone.namedfile.file import NamedBlobFile
 from plone.supermodel import model
 from Products.CMFEditions.tests.base import CMFEditionsBaseTestCase
 from StringIO import StringIO
-from unittest import TestSuite, makeSuite
+from unittest import makeSuite
+from unittest import TestSuite
 from z3c.relationfield.relation import RelationValue
-from z3c.relationfield.schema import RelationChoice, RelationList
+from z3c.relationfield.schema import RelationChoice
+from z3c.relationfield.schema import RelationList
 from ZODB.interfaces import IBlob
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility
 from zope.configuration import xmlconfig
-from zope.interface import alsoProvides, Interface
-from ..testing import VERSIONING_INTEGRATION_TESTING
+from zope.interface import provider
+from zope.interface import Interface
 
 
+@provider(IFormFieldProvider)
 class IBlobFile(model.Schema):
-        file = field.NamedBlobFile(title=u'File')
-alsoProvides(IBlobFile, IFormFieldProvider)
+    file = field.NamedBlobFile(title=u'File')
 
 
 class IRelationsType(Interface):
@@ -33,12 +37,12 @@ class IRelationsType(Interface):
                             required=False)
 
 
+@provider(IFormFieldProvider)
 class IRelationsBehavior(model.Schema):
     single = RelationChoice(title=u'Single',
                             required=False, values=[])
     multiple = RelationList(title=u'Multiple (Relations field)',
                             required=False)
-alsoProvides(IRelationsBehavior, IFormFieldProvider)
 
 
 class TestModifiers(CMFEditionsBaseTestCase):

--- a/plone/app/versioningbehavior/tests/tests.py
+++ b/plone/app/versioningbehavior/tests/tests.py
@@ -10,7 +10,7 @@ def test_suite():
     suite = unittest.TestSuite()
     suite.addTests([
         layered(
-            doctest.DocFileSuite('doctest_behavior.txt'),
+            doctest.DocFileSuite('doctest_behavior.rst'),
             layer=VERSIONING_FUNCTIONAL_TESTING,
         ),
     ])

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,11 @@
 ignore =
     *.cfg
     bootstrap.py
+
+[isort]
+force_alphabetical_sort = True
+force_single_line = True
+lines_after_imports = 2
+line_length = 200
+not_skip = __init__.py
+

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,19 @@
-from setuptools import setup, find_packages
+# -*- coding: utf-8 -*-
+from setuptools import find_packages
+from setuptools import setup
+
 import os
 
-version = '1.2.11.dev0'
+version = '2.0.0.dev0'
 
 tests_require = [
+    'plone.app.dexterity',
     'plone.app.testing',
+    'plone.app.testing',
+    'plone.namedfile[blobs]',
     'Products.CMFDiffTool',
     'Products.CMFEditions [test]',
     'Products.CMFPlone',
-    'plone.app.dexterity',
-    'plone.app.testing',
-    'plone.namedfile[blobs]',
     'zope.app.intid',
 ]
 
@@ -24,22 +27,20 @@ setup(
     # Get more strings from
     # https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
-        "Environment :: Web Environment",
-        "Framework :: Plone",
-        "Framework :: Plone :: 4.3",
-        "Framework :: Plone :: 5.0",
-        "Framework :: Plone :: 5.1",
-        "Framework :: Zope2",
-        "License :: OSI Approved :: GNU General Public License (GPL)",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
-        "Topic :: Software Development :: Libraries :: Python Modules",
+        'Environment :: Web Environment',
+        'Framework :: Plone',
+        'Framework :: Plone :: 5.1',
+        'Framework :: Zope2',
+        'License :: OSI Approved :: GNU General Public License (GPL)',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     keywords='plone dexterity behavior versioning CMFEditions',
     author='Jonas Baumann, 4teamwork GmbH',
     author_email='mailto:dexterity-development@googlegroups.com',
-    url='http://plone.org/products/dexterity',
+    url='https://pypi.org/project/plone.app.versioningbehavior',
     license='GPL version 2',
     packages=find_packages(exclude=['ez_setup']),
     namespace_packages=['plone', 'plone.app'],
@@ -48,8 +49,8 @@ setup(
     install_requires=[
         'plone.app.dexterity[relations]',
         'plone.autoform',
-        'plone.dexterity',
-        'plone.namedfile[blobs]',
+        'plone.dexterity>=2.0',
+        'plone.namedfile',
         'plone.rfc822',
         'Products.CMFEditions>2.2.9',
         'setuptools',


### PR DESCRIPTION
- pep8, isort, uth8headers, ...
- skip support for dexterity 1.x from stone age
- require blobs
- drop optional grok support
- target a version 2.0 for Plone 5.0/5.1 (1.x series for 4.3, branched already)
