### PR TITLE
Add a missing TTW edit form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Added a missing TTW edit form.
+  [Rotonen]
 
 
 1.3 (2016-12-30)

--- a/plone/app/versioningbehavior/www/SkipRelations.pt
+++ b/plone/app/versioningbehavior/www/SkipRelations.pt
@@ -1,0 +1,39 @@
+<p tal:replace="structure here/manage_page_header" omit-tag="">Header</p>
+<p tal:replace="structure here/manage_tabs" omit-tag="">tabs</p>
+
+
+<h2>Add Skip Relations</h2>
+
+<form action="manage_addSkipRelations" method="post">
+
+  <table border="0">
+
+    <tr>
+      <th>
+        Id
+      </th>
+      <td>
+        <input type="text" name="id" value="" size="40"/>
+      </td>
+    </tr>
+
+    <tr>
+      <th>
+        Title
+      </th>
+      <td>
+        <input type="text" name="title" value="" size="40"/>
+      </td>
+    </tr>
+
+    <tr>
+      <td colspan="2">
+        <input type="submit" name="submit" value="Add"/>
+      </td>
+    </tr>
+
+  </table>
+
+</form>
+
+<p tal:replace="structure here/manage_page_footer" omit-tag="">Footer</p>


### PR DESCRIPTION
This has been missing since:

https://github.com/plone/plone.app.versioningbehavior/commit/0a9a50f9bde4013ddc353d6eb03a7bac7e8e6456#diff-cbf9707e7df810dd0284fab0f0846382R39