### PR TITLE
Recover from renamed behavior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- If a behavior that provides a NamedBlobFile was renamed, we can now still find the
+  blob file, provided that the old behavior's dotted name was properly registered.
+  Refs: #45
+  [pysailor]
 
 
 1.3.6 (2018-12-10)

--- a/plone/app/versioningbehavior/browser.py
+++ b/plone/app/versioningbehavior/browser.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-from plone.app.versioningbehavior.modifiers import fetch_blob_from_history
-from plone.namedfile.interfaces import INamedBlobFile
-from plone.namedfile.interfaces import INamedBlobImage
 from plone.namedfile.utils import set_headers, stream_data
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from Products.CMFCore.utils import getToolByName
@@ -120,19 +117,6 @@ class DownloadVersion(object):
 
         if file_ is None:
             raise NotFound(self, filename, self.request)
-
-        # Make sure that we are really dealing with a file
-        if not (
-            INamedBlobFile.providedBy(file_) or
-            INamedBlobImage.providedBy(file_)
-        ):
-            return
-
-        if not file_._blob:
-            blob = fetch_blob_from_history(old_obj, field_id, version_id)
-            if not blob:
-                raise NotFound(self, filename, self.request)
-            file_._blob = blob
 
         set_headers(file_, self.request.response, filename=filename)
 

--- a/plone/app/versioningbehavior/browser.py
+++ b/plone/app/versioningbehavior/browser.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from plone.app.versioningbehavior.modifiers import fetch_blob_from_history
+from plone.namedfile.interfaces import INamedBlobFile
+from plone.namedfile.interfaces import INamedBlobImage
 from plone.namedfile.utils import set_headers, stream_data
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from Products.CMFCore.utils import getToolByName
@@ -117,6 +120,19 @@ class DownloadVersion(object):
 
         if file_ is None:
             raise NotFound(self, filename, self.request)
+
+        # Make sure that we are really dealing with a file
+        if not (
+            INamedBlobFile.providedBy(file_) or
+            INamedBlobImage.providedBy(file_)
+        ):
+            return
+
+        if not file_._blob:
+            blob = fetch_blob_from_history(old_obj, field_id, version_id)
+            if not blob:
+                raise NotFound(self, filename, self.request)
+            file_._blob = blob
 
         set_headers(file_, self.request.response, filename=filename)
 

--- a/plone/app/versioningbehavior/modifiers.py
+++ b/plone/app/versioningbehavior/modifiers.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from Acquisition import aq_base
 from AccessControl.class_init import InitializeClass
-from plone.dexterity.utils import iterSchemata, resolveDottedName
+from Acquisition import aq_base
 from plone.dexterity.interfaces import IDexterityContent
+from plone.dexterity.utils import iterSchemata, resolveDottedName
 from plone.namedfile.interfaces import INamedBlobFileField
 from plone.namedfile.interfaces import INamedBlobImageField
 from Products.CMFCore.utils import getToolByName
@@ -11,14 +11,23 @@ from Products.CMFEditions.interfaces.IModifier import IAttributeModifier
 from Products.CMFEditions.interfaces.IModifier import ICloneModifier
 from Products.CMFEditions.interfaces.IModifier import ISaveRetrieveModifier
 from Products.CMFEditions.Modifiers import ConditionalTalesModifier
+from Products.CMFEditions.utilities import dereference
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
+from z3c.relationfield.interfaces import IRelationChoice, IRelationList
 from ZODB.blob import Blob
 from zope.interface import implementer
 from zope.schema import getFields
-from z3c.relationfield.interfaces import IRelationChoice, IRelationList
+
 
 import os
 import six
+
+# XXX needs to become some kind of util lookup...
+BEHAVIOR_LOOKUP = {
+    'plone.app.contenttypes.behaviors.leadimage.ILeadImage':
+        'plone.app.contenttypes.behaviors.leadimage.ILeadImageBehavior'
+
+}
 
 
 manage_CloneNamedFileBlobsAddForm =  \
@@ -91,6 +100,33 @@ def manage_addSkipRelations(self, id, title=None, REQUEST=None):
         REQUEST['RESPONSE'].redirect(self.absolute_url() + '/manage_main')
 
 
+def fetch_blob_from_history(obj, field_name, version_id=None):
+    # For some reason, the blob cannot be retrieved from the actual
+    # object any more. A common reason can be that the behavior that provides
+    # the field was renamed.
+    # In this case, take the appropriate version from the history storage and
+    # try to retrieve the blob directly.
+    archivist_tool = getToolByName(obj, 'portal_archivist')
+    item, history_id = dereference(obj, zodb_hook=archivist_tool)
+    storage = getToolByName(obj, 'portal_historiesstorage')
+    version_data = storage.retrieve(history_id, version_id)
+    # We know that the blob will be stored under a key that starts with our
+    # class name, and that ends with the field name.
+    # Now look up the (XXX utility) mapping of changed behavior names.
+    # If the interface name of the key is found in the mapping, meaning we
+    # know that it was an interface that has now been renamed,
+    # return the blob stored under that key.
+    for key in version_data.referenced_data.keys():
+        if not key.startswith('CloneNamedFileBlobs'):
+            continue
+        name = key.split('/')[-1]
+        iface_name, f_name = name.rsplit('.', 1)
+        if f_name == field_name and iface_name in BEHAVIOR_LOOKUP:
+            blob = version_data.referenced_data[key]
+            if blob:
+                return blob
+
+
 @implementer(IAttributeModifier, ICloneModifier)
 class CloneNamedFileBlobs:
     """Modifier to save an un-cloned reference to the blob to avoid it being
@@ -127,7 +163,18 @@ class CloneNamedFileBlobs:
                         field_value = None
                     if field_value is None:
                         continue
-                    blob_file = field_value.open()
+
+                    if not field_value._blob:
+                        # Get the current version, don't pass version_id
+                        actual_field_blob = fetch_blob_from_history(obj, name)
+                    else:
+                        actual_field_blob = field_value._blob
+
+                    # The blob is simply not there. We can't do anything more.
+                    if not actual_field_blob:
+                        continue
+
+                    blob_file = actual_field_blob.open()
                     save_new = True
                     dotted_name = '.'.join([schemata.__identifier__, name])
 
@@ -135,7 +182,19 @@ class CloneNamedFileBlobs:
                         prior_obj = prior_rev.object
                         prior_blob = field.get(field.interface(prior_obj))
                         if prior_blob is not None:
-                            prior_file = prior_blob.open()
+
+                            if not prior_blob._blob:
+                                # Get the appropriate older version
+                                actual_prior_blob = fetch_blob_from_history(
+                                    obj, name, prior_rev.version_id)
+                            else:
+                                actual_prior_blob = prior_blob._blob
+
+                            # The blob is simply not there. Continue...
+                            if not actual_prior_blob:
+                                continue
+
+                            prior_file = actual_prior_blob.open()
 
                             # Check for file size differences
                             if (os.fstat(prior_file.fileno()).st_size ==
@@ -167,9 +226,13 @@ class CloneNamedFileBlobs:
     def reattachReferencedAttributes(self, obj, attrs_dict):
         obj = aq_base(obj)
         for name, blob in six.iteritems(attrs_dict):
-            iface = resolveDottedName('.'.join(name.split('.')[:-1]))
-            fname = name.split('.')[-1]
-            field = iface.get(fname)
+            iface_name, f_name = name.rsplit('.', 1)
+            # Look up if the interface might have changed
+            # XXX make this a utility lookup...
+            if iface_name in BEHAVIOR_LOOKUP:
+                iface_name = BEHAVIOR_LOOKUP[iface_name]
+            iface = resolveDottedName(iface_name)
+            field = iface.get(f_name)
             if field is not None:  # Field may have been removed from schema
                 adapted_field = field.get(iface(obj))
                 if adapted_field:

--- a/plone/app/versioningbehavior/modifiers.py
+++ b/plone/app/versioningbehavior/modifiers.py
@@ -5,6 +5,7 @@ from plone.behavior.registration import BehaviorRegistrationNotFound
 from plone.behavior.registration import lookup_behavior_registration
 from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.utils import iterSchemata
+from plone.dexterity.utils import resolveDottedName
 from plone.namedfile.interfaces import INamedBlobFileField
 from plone.namedfile.interfaces import INamedBlobImageField
 from Products.CMFCore.utils import getToolByName
@@ -170,6 +171,7 @@ class CloneNamedFileBlobs:
         obj = aq_base(obj)
         for name, blob in six.iteritems(attrs_dict):
             iface_name, f_name = name.rsplit('.', 1)
+            # In case the field is provided via a behavior:
             # Look up the behavior via dotted name.
             # If the behavior's dotted name was changed, we might still have
             # the old name in our attrs_dict.
@@ -178,9 +180,10 @@ class CloneNamedFileBlobs:
             # be found.
             try:
                 behavior = lookup_behavior_registration(iface_name)
+                iface = behavior.interface
             except BehaviorRegistrationNotFound:
-                return
-            iface = behavior.interface
+                # Not a behavior - fetch the interface directly
+                iface = resolveDottedName(iface_name)
             field = iface.get(f_name)
             if field is not None:  # Field may have been removed from schema
                 adapted_field = field.get(iface(obj))


### PR DESCRIPTION
If a behavior that provides a NamedBlob field was renamed, the following can fail:
- editing the current version of the content item
- viewing a previous version (from the history)
- reverting to a previous version

The reason is that the blob will be stored (in the depths if the history storage) under the behavior's former dotted name. The blob is not found, and all sorts of things break.

Therefore we need to be able to still find the behavior under its former name.
If plone/plone.behavior#18 gets adopted, a developer who changes a behavior will be able to register also the old dotted name, allowing it to be still found under it. This PR makes use of that enhancement.

- [x]  That means plone/plone.behavior#19 needs to be merged first before this PR makes sense.

See also #38