### PR TITLE
Avoid traceback when transforming links on content type with no primary field

### DIFF
--- a/news/51.bugfix
+++ b/news/51.bugfix
@@ -1,0 +1,2 @@
+Avoid traceback when transforming links on content type with no primary field
+[laulaz]

--- a/plone/app/versioningbehavior/browser.py
+++ b/plone/app/versioningbehavior/browser.py
@@ -104,7 +104,7 @@ class DownloadVersion(object):
         if not version_id:
             raise ValueError(u'Missing parameter on the request: version_id')
 
-        field_id = self.request.get('field_id', IPrimaryFieldInfo(self.context).fieldname)
+        field_id = self.request.get('field_id') or IPrimaryFieldInfo(self.context).fieldname
         filename = self.request.get('filename')
         do_not_stream = self.request.get('do_not_stream')
 


### PR DESCRIPTION
This refs #51

Other possible implementation : 
```
        field_id = self.request.get('field_id')
        if field_id is None:
            field_id = IPrimaryFieldInfo(self.context).fieldname
```

I have no preference ...