### PR TITLE
 Fix issue where versioning dynamic content types with blob fields broke after a schema update

### DIFF
--- a/news/57.bugfix
+++ b/news/57.bugfix
@@ -1,0 +1,2 @@
+Fix issue where versioning dynamic content types with blob fields broke after a schema update due to change in dynamic schema identifiers since plone.dexterity >= 2.10.0
+[datakurre]


### PR DESCRIPTION
 due to change in dynamic schema identifiers since plone.dexterity >= 2.10.0

Fixes #57