### PR TITLE
Depend on `plone.namedfile` core instead of its empty `[blobs]` extra.

### DIFF
--- a/news/106.bugfix
+++ b/news/106.bugfix
@@ -1,0 +1,2 @@
+Depend on `plone.namedfile` core instead of its empty `[blobs]` extra.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'plone.autoform',
         'plone.behavior>=1.1',
         'plone.dexterity',
-        'plone.namedfile[blobs]',
+        'plone.namedfile',
         'plone.rfc822',
         'Products.CMFEditions>2.2.9',
         'setuptools',


### PR DESCRIPTION
See https://github.com/plone/plone.namedfile/issues/106