### PR TITLE
Removed deprecated `plone.namedfile[blobs]` from the test requirements.

### DIFF
--- a/news/106.bugfix
+++ b/news/106.bugfix
@@ -1,0 +1,2 @@
+Removed deprecated `plone.namedfile[blobs]` from the test requirements.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,6 @@ tests_require = [
     'Products.CMFDiffTool',
     'Products.CMFEditions [test]',
     'Products.CMFPlone',
-    'plone.app.dexterity',
-    'plone.app.testing',
-    'plone.namedfile[blobs]',
 ]
 
 setup(


### PR DESCRIPTION
I overlooked this in https://github.com/plone/plone.app.versioningbehavior/pull/61

Also removed duplicate `plone.app.testing` from this list.
And removed `plone.app.dexterity`, as we already have `plone.app.dexterity[relations]` in the `install_requires`.

Note that we might want to remove `tests_requires`.
And rename the `tests` extra to the more common `test`, but this requires a change in `buildout.coredev` 5.2 and 6.0.
So maybe not for now.