### PR TITLE
Try referencing the existing blob rather than copying its contents

### DIFF
--- a/plone/app/versioningbehavior/tests/doctest_behavior.txt
+++ b/plone/app/versioningbehavior/tests/doctest_behavior.txt
@@ -80,7 +80,7 @@ interface ``plone.app.versioningbehavior.behaviors.IVersioningSupport``::
     True
 
 
-After creating the object we wan't to create a new version by simply editing it::
+After creating the object we want to create a new version by simply editing it::
 
     >>> browser.open('http://nohost/plone/testingtype/edit')
     >>> browser.getControl('Title').value = 'Blubb2'


### PR DESCRIPTION
An experiment to see whether copying the blob contents to a new blob while storing a version is really necessary. Profiling shows it's a bottleneck while creating new content that has blob fields and versioning enabled.

Not ready yet even if the tests pass; I still want to take a closer look at what happens when packing.