### PR TITLE
Add behavior IVersionable to Portal

### DIFF
--- a/news/87.feature
+++ b/news/87.feature
@@ -1,0 +1,1 @@
+Add behavior IVersionable to Portal. @wesleybl

--- a/plone/app/versioningbehavior/behaviors.py
+++ b/plone/app/versioningbehavior/behaviors.py
@@ -47,7 +47,12 @@ class IVersionable(model.Schema):
     form.no_omit(IAddForm, "changeNote")
 
 
+class IVersionablePortal(IVersionable):
+    """Even IVersionable behavior for the Portal."""
+
+
 alsoProvides(IVersionable, IFormFieldProvider)
+alsoProvides(IVersionablePortal, IFormFieldProvider)
 
 
 class IVersioningSupport(Interface):

--- a/plone/app/versioningbehavior/configure.zcml
+++ b/plone/app/versioningbehavior/configure.zcml
@@ -31,6 +31,16 @@
       marker=".behaviors.IVersioningSupport"
       />
 
+  <plone:behavior
+      name="plone.versioning.portal"
+      title="Versioning Portal"
+      description="Versioning support with CMFEditions to Portal"
+      factory=".behaviors.Versionable"
+      provides=".behaviors.IVersionablePortal"
+      for="Products.CMFPlone.Portal.PloneSite"
+      marker=".behaviors.IVersioningSupport"
+      />
+
   <subscriber
       for="plone.app.versioningbehavior.behaviors.IVersioningSupport
            zope.lifecycleevent.interfaces.IObjectModifiedEvent"


### PR DESCRIPTION
This is part of: https://github.com/plone/volto/issues/5284

In order for the working copy of `plone.app.iterate` to work in the Portal, it needs to be versionable and have the IVersionable behavior. See:

https://github.com/plone/plone.app.iterate/blob/1908aa1f4e9c95c37143fae88655469b72ea451a/plone/app/iterate/browser/control.py#L50-L52